### PR TITLE
quilt: rebuild against readline 8

### DIFF
--- a/quilt/PKGBUILD
+++ b/quilt/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname='quilt'
 pkgver=0.66
-pkgrel=1
+pkgrel=2
 pkgdesc='Manage large numbers of patches'
 url='https://savannah.nongnu.org/projects/quilt'
 groups=('base-devel')


### PR DESCRIPTION
quilt copies awk into `/usr/share/quilt/compat` at build time, but this hasn't been built against readline 8.